### PR TITLE
Add run-local batch script for local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This project is a simple web-based roguelike.
 
+## Running locally
+Double-click `run-local.bat` to install dependencies and start a local server on port 8080.
+
 ## Configuration
 `src/config.js` exposes tunable parameters:
 

--- a/run-local.bat
+++ b/run-local.bat
@@ -1,0 +1,5 @@
+@echo off
+cd /d %~dp0
+call npm install
+npx http-server -p 8080
+pause


### PR DESCRIPTION
## Summary
- add `run-local.bat` script to install dependencies and launch an HTTP server on port 8080
- document script usage in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec9c0c088832698bb7ef7f06faf9e