### PR TITLE
Add run-local script and pixel-styled UI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This project is a simple web-based roguelike.
 
+## Running locally
+Double-click `run-local.bat` to install dependencies and start a local server on port 8080.
+
 ## Configuration
 `src/config.js` exposes tunable parameters:
 

--- a/index.html
+++ b/index.html
@@ -6,13 +6,12 @@
 <style>
 body { font-family:sans-serif; background:#111; color:#eee; text-align:center; }
 .screen { display:none; }
-canvas { image-rendering:pixelated; width:128px; height:128px; border:1px solid #555; background:#222; margin:10px auto; }
+canvas { image-rendering:pixelated; border:1px solid #555; background:#222; margin:10px auto; }
 #dungeon { position:relative; }
-#battleCanvas { height:64px; }
 #eventText { white-space:pre-line; margin-top:10px; }
 .damage { position:absolute; pointer-events:none; color:#ff0; animation:float 1s ease-out forwards; }
 @keyframes float { from{opacity:1; transform:translateY(0);} to{opacity:0; transform:translateY(-20px);} }
-.popup { position:fixed; top:20%; left:50%; transform:translateX(-50%); background:#222; padding:10px; border:1px solid #555; display:none; }
+.popup { position:fixed; transform:translateX(-50%); background:#222; padding:10px; border:1px solid #555; display:none; font-family:monospace; image-rendering:pixelated; }
 .inventory-slot { width:32px; height:32px; border:1px solid #555; display:inline-block; margin:2px; }
 </style>
 </head>
@@ -23,7 +22,7 @@ canvas { image-rendering:pixelated; width:128px; height:128px; border:1px solid 
 </div>
 
 <div id="creation" class="screen">
-  <canvas id="creationCanvas" width="32" height="32"></canvas>
+  <canvas id="creationCanvas"></canvas>
   <div id="alloc"></div>
   <p>Свободных очков: <span id="points">4</span></p>
   <input id="nameInput" placeholder="Имя" />
@@ -31,7 +30,7 @@ canvas { image-rendering:pixelated; width:128px; height:128px; border:1px solid 
 </div>
 
 <div id="room" class="screen">
-  <canvas id="heroCanvas" width="32" height="32"></canvas>
+  <canvas id="heroCanvas"></canvas>
   <div id="roomStats"></div>
   <button id="dungeonBtn">Отправиться в подземелье</button>
   <div>
@@ -43,7 +42,7 @@ canvas { image-rendering:pixelated; width:128px; height:128px; border:1px solid 
 </div>
 
 <div id="dungeon" class="screen">
-  <canvas id="battleCanvas" width="128" height="64"></canvas>
+  <canvas id="battleCanvas"></canvas>
   <div id="eventText"></div>
 </div>
 
@@ -71,6 +70,11 @@ canvas { image-rendering:pixelated; width:128px; height:128px; border:1px solid 
   <h3>Магазин</h3>
   <div id="shopItems"></div>
   <button class="close">X</button>
+</div>
+
+<div id="modalPopup" class="popup">
+  <div id="modalText"></div>
+  <div id="modalActions"></div>
 </div>
 
 <script type="module" src="main.js"></script>

--- a/run-local.bat
+++ b/run-local.bat
@@ -1,0 +1,5 @@
+@echo off
+cd /d %~dp0
+call npm install
+npx http-server -p 8080
+pause

--- a/src/ui-config.js
+++ b/src/ui-config.js
@@ -1,0 +1,8 @@
+export const UI_CONFIG = {
+  canvases: {
+    creationCanvas: { width:32, height:32, displayWidth:128, displayHeight:128 },
+    heroCanvas: { width:32, height:32, displayWidth:128, displayHeight:128 },
+    battleCanvas: { width:128, height:64, displayWidth:128, displayHeight:64 }
+  },
+  popup: { top: '20%', left: '50%' }
+};


### PR DESCRIPTION
## Summary
- add `run-local.bat` script to install dependencies and launch an HTTP server on port 8080
- style all modal windows in a unified pixel aesthetic with action buttons
- centralize interface sizes and positions in `src/ui-config.js` for easy layout tweaks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec9c0c088832698bb7ef7f06faf9e